### PR TITLE
Webapi login using email address as username.

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -186,7 +186,8 @@ wf_check_login <- function(user, key, service) {
       encode = "json"
     )
     return(!httr::http_error(info) &&
-             (httr::content(info)$uid == user))
+           (any(user %in% unclass(httr::content(info)[c("uid", "email")]))))
+
   }
 
   # CDS service


### PR DESCRIPTION
Dear all,

**Problem:** I just got an email from a user running into a problem when calling `wf_set_key(user = user, key = key, service = "webapi")` when using his email address as `user` as suggested by ECMWF (see <https://api.ecmwf.int/v1/key>).

**Reason:** Traced it back to `wf_check_login()` where the details are sent to the `who-am-i` API to check if the login details are correct. In case the request status code is OK we only check `content(info)$uid` against function input `user`. In case `user` is the email address (and not the ECMWF username) this check fails.

**Solution:** I have adjusted the check and as if the function input (`user`) is either identical to `$uid` or `$email`, such that it works with both, email or ECMWF username.

Might be useful to add to the package?

Thanks and all best,
Reto

---

Minimal for testing:

```
# Login credentials
USER  <- "xzy"
EMAIL <- "your.mail@example.com"
KEY   <- "abcdefghijklmnopqrstufwxyz123456789"

# Manual test
info <- httr::GET("https://api.ecmwf.int/v1/who-am-i",
      httr::add_headers(
        "Accept" = "application/json",
        "Content-Type" = "application/json",
        "From" = USER,
        "X-ECMWF-KEY" = KEY),
      encode = "json"
    )

print(httr::content(info))

cat("Using", USER, "to login.\n")
wf_set_key(user = USER, key = KEY, service = "webapi")

cat("Using", EMAIL, "to login.\n")
wf_set_key(user = EMAIL, key = KEY, service = "webapi")
```



 