### PR TITLE
Patch batch request issue

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ecmwfr
 Title: Interface to 'ECMWF' and 'CDS' Data Web Services
-Version: 1.5.0
+Version: 1.5.1
 Authors@R: c(person(
                family = "Hufkens",
                given = "Koen",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # ecmwfr 1.5.1
 
-* `wf_request_batch()` logic patch, to keep running on a 202 http error
+* `wf_request_batch()` logic patch for 202 http error on long runs
 
 # ecmwfr 1.5.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # ecmwfr 1.5.1
 
-* `wf_request_batch()` logic patch for 202 http error on long runs
+* Logic patch for 202 http error on long runs
 
 # ecmwfr 1.5.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# ecmwfr 1.5.1
+
+* `wf_request_batch()` logic patch, to keep running on a 202 http error
+
 # ecmwfr 1.5.0
 
 * `wf_request()` now accepts CDS Toolbox API workflow calls

--- a/R/service-cds.R
+++ b/R/service-cds.R
@@ -94,9 +94,7 @@ cds_service <- R6::R6Class("ecmwfr_cds",
       if (private$status != "completed" || is.null(private$status)) {
         private$code <- 202
         private$file_url <- NA # just ot be on the safe side
-      }
-
-      if (private$status == "completed") {
+      } else if (private$status == "completed") {
         private$code <- 302
         private$file_url <- private$get_location(ct)
       } else if (private$status == "failed") {

--- a/R/wf_request_batch.R
+++ b/R/wf_request_batch.R
@@ -63,11 +63,6 @@ wf_request_batch <- function(
 
       # Try to download
       if (!isFALSE(slots[[w]])) {
-
-        # put the breaks on polling
-        # not to spam the API
-        Sys.sleep(3)
-
         slots[[w]]$download()
       }
 

--- a/R/wf_request_batch.R
+++ b/R/wf_request_batch.R
@@ -63,6 +63,11 @@ wf_request_batch <- function(
 
       # Try to download
       if (!isFALSE(slots[[w]])) {
+
+        # put the breaks on polling
+        # not to spam the API
+        Sys.sleep(3)
+
         slots[[w]]$download()
       }
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -133,15 +133,14 @@ exit_message <- function(url, service, path, file) {
       vers,
       ". Please respect the terms of use:\n",
       "     - https://cds.climate.copernicus.eu/disclaimer-privacy\n",
-      "     - https://www.ecmwf.int/en/terms-use\n",
-      " (note: using http version 1.1)"
+      "     - https://www.ecmwf.int/en/terms-use\n"
     )
     if (interactive())
       packageStartupMessage(txt)
 
     # force non http/2 transfers to avoid
     # batch processing issues
-    httr::set_config(httr::config(http_version = 1))
+    #httr::set_config(httr::config(http_version = 1))
   }
 
 # check if server is reachable

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -125,16 +125,23 @@ exit_message <- function(url, service, path, file) {
 .onAttach <-
   function(libname = find.package("ecmwfr"),
            pkgname = "ecmwfr") {
+
+    # startup messages
     vers <- as.character(utils::packageVersion("ecmwfr"))
     txt <- paste(
       "\n     This is 'ecmwfr' version ",
       vers,
       ". Please respect the terms of use:\n",
       "     - https://cds.climate.copernicus.eu/disclaimer-privacy\n",
-      "     - https://www.ecmwf.int/en/terms-use\n"
+      "     - https://www.ecmwf.int/en/terms-use\n",
+      " (note: using http version 1.1)"
     )
     if (interactive())
       packageStartupMessage(txt)
+
+    # force non http/2 transfers to avoid
+    # batch processing issues
+    httr::set_config(httr::config(http_version = 1))
   }
 
 # check if server is reachable

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -139,8 +139,9 @@ exit_message <- function(url, service, path, file) {
       packageStartupMessage(txt)
 
     # force non http/2 transfers to avoid
-    # batch processing issues
-    httr::set_config(httr::config(http_version = 1))
+    # batch processing issues (set to 1)
+    httr::set_config(httr::config(http_version = 2))
+    #breaks SSL, but enables long batch processes
   }
 
 # check if server is reachable

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -138,10 +138,8 @@ exit_message <- function(url, service, path, file) {
     if (interactive())
       packageStartupMessage(txt)
 
-    # force non http/2 transfers to avoid
-    # batch processing issues (set to 1)
+    # force http/2 for all products
     httr::set_config(httr::config(http_version = 2))
-    #breaks SSL, but enables long batch processes
   }
 
 # check if server is reachable

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -140,7 +140,7 @@ exit_message <- function(url, service, path, file) {
 
     # force non http/2 transfers to avoid
     # batch processing issues
-    #httr::set_config(httr::config(http_version = 1))
+    httr::set_config(httr::config(http_version = 1))
   }
 
 # check if server is reachable

--- a/analysis/debugging.R
+++ b/analysis/debugging.R
@@ -1,0 +1,24 @@
+# tracking issue #117 https://github.com/bluegreen-labs/ecmwfr/issues/117
+
+my_request <- list(
+  stream = "oper",
+  levtype = "sfc",
+  param = "165.128/166.128/167.128",
+  dataset = "interim",
+  step = "0",
+  grid = "0.75/0.75",
+  time = "00/06/12/18",
+  date = "2014-07-01/to/2014-07-31",
+  type = "an",
+  class = "ei",
+  area = "73.5/-27/33/45",
+  format = "netcdf",
+  target = "tmp.nc"
+)
+
+wf_request(
+  user = "info@bluegreenlabs.org",
+  request = my_request,
+  transfer = TRUE,
+  path = "~"
+)

--- a/tests/testthat/test_ads.R
+++ b/tests/testthat/test_ads.R
@@ -13,8 +13,8 @@ login_check <- FALSE
 # check if on github
 ON_GIT <- ifelse(
   length(Sys.getenv("GITHUB_TOKEN")) <= 1,
-  TRUE,
-  FALSE
+  FALSE,
+  TRUE
 )
 
 ads_request <- list(

--- a/tests/testthat/test_ads.R
+++ b/tests/testthat/test_ads.R
@@ -8,7 +8,6 @@ if(!("ecmwfr" %in% keyring::keyring_list()$keyring)){
 
 #opts <- options(keyring_warn_for_env_fallback = FALSE)
 #on.exit(options(opts), add = TRUE)
-login_check <- NA
 
 ads_request <- list(
   date = "2003-01-01/2003-01-01",
@@ -20,7 +19,7 @@ ads_request <- list(
 )
 
 # ignore SSL (server has SSL issues)
-httr::set_config(httr::config(ssl_verifypeer = 0L))
+#httr::set_config(httr::config(ssl_verifypeer = 0L))
 
 # is the server reachable
 server_check <- ecmwfr:::ecmwf_running(ecmwfr:::wf_server(service = "ads"))
@@ -32,10 +31,16 @@ if(server_check){
     try(
       wf_set_key(user = "2161",
                  key = Sys.getenv("ADS"),
-                 service = "ads")
-    )
+                 service = "ads"))
+
+  # set login check to TRUE so skipped if
+  # the user is not created
   login_check <- inherits(user, "try-error")
+} else {
+  # skip if the server is not reachable
+  login_check <- TRUE
 }
+
 
 #----- formal checks ----
 

--- a/tests/testthat/test_ads.R
+++ b/tests/testthat/test_ads.R
@@ -13,9 +13,9 @@ login_check <- FALSE
 # check if on github
 ON_GIT <- ifelse(
   length(Sys.getenv("GITHUB_TOKEN")) <= 1,
-  FALSE,
-  TRUE
-  )
+  TRUE,
+  FALSE
+)
 
 ads_request <- list(
   date = "2003-01-01/2003-01-01",
@@ -34,7 +34,7 @@ server_check <- ecmwfr:::ecmwf_running(ecmwfr:::wf_server(service = "ads"))
 
 # if the server is reachable, try to set login
 # if not set login check to TRUE as well
-if(server_check){
+if(server_check & ON_GIT){
   user <-
     try(
       wf_set_key(user = "2161",
@@ -44,11 +44,7 @@ if(server_check){
   # set login check to TRUE so skipped if
   # the user is not created
   login_check <- inherits(user, "try-error")
-} else {
-  # skip if the server is not reachable
-  login_check <- TRUE
 }
-
 
 #----- formal checks ----
 

--- a/tests/testthat/test_ads.R
+++ b/tests/testthat/test_ads.R
@@ -8,6 +8,14 @@ if(!("ecmwfr" %in% keyring::keyring_list()$keyring)){
 
 #opts <- options(keyring_warn_for_env_fallback = FALSE)
 #on.exit(options(opts), add = TRUE)
+login_check <- FALSE
+
+# check if on github
+ON_GIT <- ifelse(
+  length(Sys.getenv("GITHUB_TOKEN")) <= 1,
+  FALSE,
+  TRUE
+  )
 
 ads_request <- list(
   date = "2003-01-01/2003-01-01",

--- a/tests/testthat/test_ads.R
+++ b/tests/testthat/test_ads.R
@@ -8,7 +8,6 @@ if(!("ecmwfr" %in% keyring::keyring_list()$keyring)){
 
 #opts <- options(keyring_warn_for_env_fallback = FALSE)
 #on.exit(options(opts), add = TRUE)
-login_check <- FALSE
 
 # check if on github
 ON_GIT <- ifelse(
@@ -37,14 +36,34 @@ server_check <- ecmwfr:::ecmwf_running(ecmwfr:::wf_server(service = "ads"))
 if(server_check & ON_GIT){
   user <-
     try(
-      wf_set_key(user = "2161",
-                 key = Sys.getenv("ADS"),
-                 service = "ads"))
+      wf_set_key(
+        user = "2161",
+        key = Sys.getenv("ADS"),
+        service = "ads")
+      )
 
   # set login check to TRUE so skipped if
   # the user is not created
   login_check <- inherits(user, "try-error")
+} else {
+  login_check <- TRUE
 }
+
+#---- check server active ----
+test_that("Server up? Fails if not",{
+  skip_on_cran()
+
+  # check retrieval
+  expect_true(server_check)
+})
+
+#---- Login well set ----
+test_that("Could the login be set? Fails if not",{
+  skip_on_cran()
+
+  # check retrieval
+  expect_true(login_check)
+})
 
 #----- formal checks ----
 

--- a/tests/testthat/test_ads.R
+++ b/tests/testthat/test_ads.R
@@ -31,10 +31,9 @@ if(server_check){
   user <-
     try(
       wf_set_key(user = "2161",
-                 key = system("echo $ADS", intern = TRUE),
+                 key = Sys.getenv("ADS"),
                  service = "ads")
     )
-  print(user)
   login_check <- inherits(user, "try-error")
 }
 

--- a/tests/testthat/test_ads.R
+++ b/tests/testthat/test_ads.R
@@ -51,6 +51,7 @@ if(server_check & ON_GIT){
 test_that("ads datasets returns data.frame or list", {
   skip_on_cran()
   skip_if(login_check)
+  skip_if(!server_check)
   expect_true(inherits(wf_datasets(user = "2161",
                                    service = "ads",
                                    simplify = TRUE), "data.frame"))
@@ -63,6 +64,7 @@ test_that("ads datasets returns data.frame or list", {
 test_that("ads request", {
   skip_on_cran()
   skip_if(login_check)
+  skip_if(!server_check)
 
   # ok transfer
   expect_message(wf_request(user = "2161",
@@ -74,6 +76,8 @@ test_that("ads request", {
 test_that("check ADS product info",{
   skip_on_cran()
   skip_if(login_check)
+  skip_if(!server_check)
+
   expect_output(
     str(wf_product_info("cams-global-reanalysis-eac4",
                         service = "ads",
@@ -83,6 +87,7 @@ test_that("check ADS product info",{
 test_that("batch request works", {
   skip_on_cran()
   skip_if(login_check)
+  skip_if(!server_check)
 
   years <- c(2017,2018)
 

--- a/tests/testthat/test_cds.R
+++ b/tests/testthat/test_cds.R
@@ -6,10 +6,8 @@ if(!("ecmwfr" %in% keyring::keyring_list()$keyring)){
   keyring::keyring_create("ecmwfr", password = "test")
 }
 
-login_check <- NA
-
 # ignore SSL (server has SSL issues)
-httr::set_config(httr::config(ssl_verifypeer = 0L))
+#httr::set_config(httr::config(ssl_verifypeer = 0L))
 
 # format request (see below)
 cds_request <- list(
@@ -54,8 +52,13 @@ if(server_check){
         key = Sys.getenv("CDS"),
         service = "cds")
       )
-  print(user)
+
+  # set login check to TRUE so skipped if
+  # the user is not created
   login_check <- inherits(user, "try-error")
+} else {
+  # skip if the server is not reachable
+  login_check <- TRUE
 }
 
 #----- formal checks ----

--- a/tests/testthat/test_cds.R
+++ b/tests/testthat/test_cds.R
@@ -65,6 +65,8 @@ if(server_check & ON_GIT){
   # set login check to TRUE so skipped if
   # the user is not created
   login_check <- inherits(user, "try-error")
+} else {
+  login_check <- TRUE
 }
 
 #----- formal checks ----

--- a/tests/testthat/test_cds.R
+++ b/tests/testthat/test_cds.R
@@ -11,8 +11,8 @@ login_check <- FALSE
 # check if on github
 ON_GIT <- ifelse(
   length(Sys.getenv("GITHUB_TOKEN")) <= 1,
-  TRUE,
-  FALSE
+  FALSE,
+  TRUE
 )
 
 # ignore SSL (server has SSL issues)
@@ -68,7 +68,6 @@ if(server_check & ON_GIT){
 }
 
 #----- formal checks ----
-
 test_that("set key", {
   skip_on_cran()
   skip_if(login_check)

--- a/tests/testthat/test_cds.R
+++ b/tests/testthat/test_cds.R
@@ -11,8 +11,8 @@ login_check <- FALSE
 # check if on github
 ON_GIT <- ifelse(
   length(Sys.getenv("GITHUB_TOKEN")) <= 1,
-  FALSE,
-  TRUE
+  TRUE,
+  FALSE
 )
 
 # ignore SSL (server has SSL issues)
@@ -54,7 +54,7 @@ server_check <- ecmwfr:::ecmwf_running(ecmwfr:::wf_server(service = "cds"))
 
 # if the server is reachable, try to set login
 # if not set login check to TRUE as well
-if(server_check && ON_GIT){
+if(server_check & ON_GIT){
   user <- try(
       ecmwfr::wf_set_key(
         user = "2088",

--- a/tests/testthat/test_cds.R
+++ b/tests/testthat/test_cds.R
@@ -6,6 +6,15 @@ if(!("ecmwfr" %in% keyring::keyring_list()$keyring)){
   keyring::keyring_create("ecmwfr", password = "test")
 }
 
+login_check <- FALSE
+
+# check if on github
+ON_GIT <- ifelse(
+  length(Sys.getenv("GITHUB_TOKEN")) <= 1,
+  FALSE,
+  TRUE
+)
+
 # ignore SSL (server has SSL issues)
 #httr::set_config(httr::config(ssl_verifypeer = 0L))
 
@@ -45,7 +54,7 @@ server_check <- ecmwfr:::ecmwf_running(ecmwfr:::wf_server(service = "cds"))
 
 # if the server is reachable, try to set login
 # if not set login check to TRUE as well
-if(server_check){
+if(server_check && ON_GIT){
   user <- try(
       ecmwfr::wf_set_key(
         user = "2088",
@@ -56,9 +65,6 @@ if(server_check){
   # set login check to TRUE so skipped if
   # the user is not created
   login_check <- inherits(user, "try-error")
-} else {
-  # skip if the server is not reachable
-  login_check <- TRUE
 }
 
 #----- formal checks ----

--- a/tests/testthat/test_cds_workflows.R
+++ b/tests/testthat/test_cds_workflows.R
@@ -6,8 +6,6 @@ if(!("ecmwfr" %in% keyring::keyring_list()$keyring)){
   keyring::keyring_create("ecmwfr", password = "test")
 }
 
-login_check <- FALSE
-
 # check if on github
 ON_GIT <- ifelse(
   length(Sys.getenv("GITHUB_TOKEN")) <= 1,
@@ -32,6 +30,8 @@ if(server_check & ON_GIT) {
   # set login check to TRUE so skipped if
   # the user is not created
   login_check <- inherits(user, "try-error")
+} else {
+  login_check <- TRUE
 }
 
 #----- formal checks ----
@@ -40,6 +40,7 @@ if(server_check & ON_GIT) {
 test_that("set key", {
   skip_on_cran()
   skip_if(login_check)
+  skip_if(!server_check)
 
   # basic request for data via python
   # one line as indentation matters

--- a/tests/testthat/test_cds_workflows.R
+++ b/tests/testthat/test_cds_workflows.R
@@ -6,12 +6,21 @@ if(!("ecmwfr" %in% keyring::keyring_list()$keyring)){
   keyring::keyring_create("ecmwfr", password = "test")
 }
 
+login_check <- FALSE
+
+# check if on github
+ON_GIT <- ifelse(
+  length(Sys.getenv("GITHUB_TOKEN")) <= 1,
+  FALSE,
+  TRUE
+)
+
 # is the server reachable
 server_check <- ecmwfr:::ecmwf_running(ecmwfr:::wf_server(service = "cds"))
 
 # if the server is reachable, try to set login
 # if not set login check to TRUE as well
-if(server_check) {
+if(server_check && ON_GIT) {
   user <-try(
       wf_set_key(
         user = "2088",
@@ -23,11 +32,7 @@ if(server_check) {
   # set login check to TRUE so skipped if
   # the user is not created
   login_check <- inherits(user, "try-error")
-} else {
-  # skip if the server is not reachable
-  login_check <- TRUE
 }
-
 
 #----- formal checks ----
 

--- a/tests/testthat/test_cds_workflows.R
+++ b/tests/testthat/test_cds_workflows.R
@@ -11,8 +11,8 @@ login_check <- FALSE
 # check if on github
 ON_GIT <- ifelse(
   length(Sys.getenv("GITHUB_TOKEN")) <= 1,
-  TRUE,
-  FALSE
+  FALSE,
+  TRUE
 )
 
 # is the server reachable

--- a/tests/testthat/test_cds_workflows.R
+++ b/tests/testthat/test_cds_workflows.R
@@ -11,8 +11,8 @@ login_check <- FALSE
 # check if on github
 ON_GIT <- ifelse(
   length(Sys.getenv("GITHUB_TOKEN")) <= 1,
-  FALSE,
-  TRUE
+  TRUE,
+  FALSE
 )
 
 # is the server reachable
@@ -20,7 +20,7 @@ server_check <- ecmwfr:::ecmwf_running(ecmwfr:::wf_server(service = "cds"))
 
 # if the server is reachable, try to set login
 # if not set login check to TRUE as well
-if(server_check && ON_GIT) {
+if(server_check & ON_GIT) {
   user <-try(
       wf_set_key(
         user = "2088",

--- a/tests/testthat/test_cds_workflows.R
+++ b/tests/testthat/test_cds_workflows.R
@@ -19,8 +19,15 @@ if(server_check) {
         service = "cds"
         )
     )
+
+  # set login check to TRUE so skipped if
+  # the user is not created
   login_check <- inherits(user, "try-error")
+} else {
+  # skip if the server is not reachable
+  login_check <- TRUE
 }
+
 
 #----- formal checks ----
 

--- a/tests/testthat/test_webapi.r
+++ b/tests/testthat/test_webapi.r
@@ -7,7 +7,7 @@ if(!("ecmwfr" %in% keyring::keyring_list()$keyring)){
 }
 
 # ignore SSL (server has SSL issues)
-httr::set_config(httr::config(ssl_verifypeer = 0L))
+#httr::set_config(httr::config(ssl_verifypeer = 0L))
 
 # format request (see below)
 my_request <- list(
@@ -37,7 +37,13 @@ if(server_check){
       key = Sys.getenv("WEBAPI"),
       service = "webapi"
     ))
+
+  # set login check to TRUE so skipped if
+  # the user is not created
   login_check <- inherits(user, "try-error")
+} else {
+  # skip if the server is not reachable
+  login_check <- TRUE
 }
 
 #----- formal checks ----

--- a/tests/testthat/test_webapi.r
+++ b/tests/testthat/test_webapi.r
@@ -13,8 +13,8 @@ login_check <- FALSE
 # check if on github
 ON_GIT <- ifelse(
   length(Sys.getenv("GITHUB_TOKEN")) <= 1,
-  FALSE,
-  TRUE
+  TRUE,
+  FALSE
 )
 
 # format request (see below)
@@ -38,7 +38,7 @@ my_request <- list(
 server_check <- ecmwfr:::ecmwf_running(ecmwfr:::wf_server(service = "webapi"))
 
 # if server is up, create login
-if(server_check && ON_GIT){
+if(server_check & ON_GIT){
   user <- try(
     wf_set_key(
       user = "info@bluegreenlabs.org",

--- a/tests/testthat/test_webapi.r
+++ b/tests/testthat/test_webapi.r
@@ -13,8 +13,8 @@ login_check <- FALSE
 # check if on github
 ON_GIT <- ifelse(
   length(Sys.getenv("GITHUB_TOKEN")) <= 1,
-  TRUE,
-  FALSE
+  FALSE,
+  TRUE
 )
 
 # format request (see below)

--- a/tests/testthat/test_webapi.r
+++ b/tests/testthat/test_webapi.r
@@ -8,7 +8,6 @@ if(!("ecmwfr" %in% keyring::keyring_list()$keyring)){
 
 # ignore SSL (server has SSL issues)
 #httr::set_config(httr::config(ssl_verifypeer = 0L))
-login_check <- FALSE
 
 # check if on github
 ON_GIT <- ifelse(
@@ -44,11 +43,14 @@ if(server_check & ON_GIT){
       user = "info@bluegreenlabs.org",
       key = Sys.getenv("WEBAPI"),
       service = "webapi"
-    ))
+    )
+  )
 
   # set login check to TRUE so skipped if
   # the user is not created
   login_check <- inherits(user, "try-error")
+} else {
+  login_check <- TRUE
 }
 
 #---- check server active ----

--- a/tests/testthat/test_webapi.r
+++ b/tests/testthat/test_webapi.r
@@ -56,6 +56,7 @@ if(server_check & ON_GIT){
 test_that("set, get secret key",{
   skip_on_cran()
   skip_if(login_check)
+  skip_if(!server_check)
 
   # check retrieval
   expect_error(wf_get_key(user = "info@bluegreenlabs.org"))
@@ -64,18 +65,24 @@ test_that("set, get secret key",{
 test_that("test dataset function", {
   skip_on_cran()
   skip_if(login_check)
+  skip_if(!server_check)
+
   expect_output(str(wf_datasets(user = "info@bluegreenlabs.org")))
 })
 
 test_that("test dataset function - no login", {
   skip_on_cran()
   skip_if(login_check)
+  skip_if(!server_check)
+
   expect_error(wf_datasets())
 })
 
 test_that("test services function", {
   skip_on_cran()
   skip_if(login_check)
+  skip_if(!server_check)
+
   expect_output(str(wf_services(user = "info@bluegreenlabs.org")))
 })
 
@@ -88,18 +95,24 @@ test_that("test services function - no login", {
 test_that("test user info function", {
   skip_on_cran()
   skip_if(login_check)
+  skip_if(!server_check)
+
   expect_output(str(wf_user_info(user = "info@bluegreenlabs.org")))
 })
 
 test_that("test user info function - no login", {
   skip_on_cran()
   skip_if(login_check)
+  skip_if(!server_check)
+
   expect_error(wf_user_info())
 })
 
 test_that("test request (transfer) function", {
   skip_on_cran()
   skip_if(login_check)
+  skip_if(!server_check)
+
   expect_type(
     wf_request(
       user = "info@bluegreenlabs.org",
@@ -113,6 +126,7 @@ test_that("test request (transfer) function", {
 test_that("test request (transfer) function", {
   skip_on_cran()
   skip_if(login_check)
+  skip_if(!server_check)
 
   # create new output dir in tempdir()
   path <- file.path(tempdir(),"/test/")
@@ -129,6 +143,7 @@ test_that("test request (transfer) function", {
 test_that("test request (transfer) function - time out", {
   skip_on_cran()
   skip_if(login_check)
+  skip_if(!server_check)
 
   expect_output(str(wf_request(
     user = "info@bluegreenlabs.org",
@@ -140,6 +155,7 @@ test_that("test request (transfer) function - time out", {
 test_that("test request (transfer) function - no transfer", {
   skip_on_cran()
   skip_if(login_check)
+  skip_if(!server_check)
 
   ct <- wf_request(
     user = "info@bluegreenlabs.org",
@@ -170,6 +186,7 @@ test_that("test request (transfer) function - no transfer", {
 test_that("test request (transfer) function - no email", {
   skip_on_cran()
   skip_if(login_check)
+  skip_if(!server_check)
 
   expect_error(wf_request())
 })
@@ -177,6 +194,7 @@ test_that("test request (transfer) function - no email", {
 test_that("test transfer function - no login", {
   skip_on_cran()
   skip_if(login_check)
+  skip_if(!server_check)
 
   expect_error(wf_transfer())
 })
@@ -184,6 +202,7 @@ test_that("test transfer function - no login", {
 test_that("list datasets webapi",{
   skip_on_cran()
   skip_if(login_check)
+  skip_if(!server_check)
 
   expect_output(str(wf_datasets(user = "info@bluegreenlabs.org",
                                 service = "webapi")))
@@ -195,6 +214,7 @@ test_that("list datasets webapi",{
 test_that("test request (transfer) function", {
   skip_on_cran()
   skip_if(login_check)
+  skip_if(!server_check)
 
   expect_message(
     wf_request(
@@ -220,6 +240,7 @@ test_that("check product info",{
 test_that("test delete function - no login", {
   skip_on_cran()
   skip_if(login_check)
+  skip_if(!server_check)
 
   expect_error(wf_delete())
 })
@@ -227,6 +248,7 @@ test_that("test delete function - no login", {
 test_that("check request - no dataset field", {
   skip_on_cran()
   skip_if(login_check)
+  skip_if(!server_check)
 
   my_request <- list(
     stream = "oper",
@@ -251,6 +273,7 @@ test_that("check request - no dataset field", {
 test_that("check request - bad request type", {
   skip_on_cran()
   skip_if(login_check)
+  skip_if(!server_check)
 
   my_request <- "xyz"
   expect_error(
@@ -263,6 +286,7 @@ test_that("check request - bad request type", {
 test_that("check mars request - no target", {
   skip_on_cran()
   skip_if(login_check)
+  skip_if(!server_check)
 
   my_request <- list(
     stream = "oper",
@@ -288,6 +312,7 @@ test_that("check mars request - no target", {
 test_that("check request - no netcdf grid specified", {
   skip_on_cran()
   skip_if(login_check)
+  skip_if(!server_check)
 
   my_request <- list(
     stream = "oper",
@@ -312,6 +337,7 @@ test_that("check request - no netcdf grid specified", {
 test_that("check request - bad credentials", {
   skip_on_cran()
   skip_if(login_check)
+  skip_if(!server_check)
 
   my_request <- list(
     stream = "oper",
@@ -338,6 +364,7 @@ test_that("check request - bad credentials", {
 test_that("job_name has to be valid", {
   skip_on_cran()
   skip_if(login_check)
+  skip_if(!server_check)
 
   my_request <- list(
     stream = "oper",
@@ -364,6 +391,7 @@ test_that("job_name has to be valid", {
 test_that("batch request", {
   skip_on_cran()
   skip_if(login_check)
+  skip_if(!server_check)
 
   years <- c(2017,2018)
   requests <- lapply(years, function(y) {
@@ -395,6 +423,7 @@ test_that("batch request", {
 test_that("wf_transfer() check", {
   skip_on_cran()
   skip_if(login_check)
+  skip_if(!server_check)
 
   request <- list(
     stream = "oper",

--- a/tests/testthat/test_webapi.r
+++ b/tests/testthat/test_webapi.r
@@ -34,10 +34,9 @@ if(server_check){
   user <- try(
     wf_set_key(
       user = "info@bluegreenlabs.org",
-      key = system("echo $WEBAPI", intern = TRUE),
+      key = Sys.getenv("WEBAPI"),
       service = "webapi"
     ))
-  print(user)
   login_check <- inherits(user, "try-error")
 }
 

--- a/tests/testthat/test_webapi.r
+++ b/tests/testthat/test_webapi.r
@@ -51,6 +51,22 @@ if(server_check & ON_GIT){
   login_check <- inherits(user, "try-error")
 }
 
+#---- check server active ----
+test_that("Server up? Fails if not",{
+  skip_on_cran()
+
+  # check retrieval
+  expect_true(server_check)
+})
+
+#---- Login well set ----
+test_that("Could the login be set? Fails if not",{
+  skip_on_cran()
+
+  # check retrieval
+  expect_true(login_check)
+})
+
 #----- formal checks ----
 
 test_that("set, get secret key",{


### PR DESCRIPTION
This patches an issue on long runs, when hitting a 202 http return.

Quoting https://github.com/bluegreen-labs/ecmwfr/issues/105

> Root cause is this statement which is split from the rest of the if - -if else logic.
> 
> https://github.com/bluegreen-labs/ecmwfr/blob/c3e0e8f365bf8431c3e0dbb0a6d1a8f270643e1d/R/service-cds.R#L94
> 
> When `is.null(private$status)` is true, values of `private` are set but this will not skip the evaluation of the next if statement.
> 
> when `private$status` is NULL in the next if() this statement will fail and error. Running a long run now to test stability.

