### PR TITLE
Minor doc suggestion

### DIFF
--- a/R/wf_set_key.R
+++ b/R/wf_set_key.R
@@ -68,8 +68,8 @@ wf_set_key <- function(key, user = "ecmwfr") {
         )
     }
     browseURL(wf_key_page(service))
-    message("Login or register to get a Personal Access Token")
-    key <- getPass::getPass(msg = "Personal Access Token: ")
+    message("Login or register to get a API Token")
+    key <- getPass::getPass(msg = "API Token: ")
     if (is.null(key))
       stop("No key supplied.")
   }

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ to the ECMWF using [the public forum](https://forum.ecmwf.int/t/changes-to-grib-
 ## Use: ECMWF Data Store services
 
 Create a ECMWF account by [self
-registering](https://accounts.ecmwf.int/auth/realms/ecmwf/protocol/openid-connect/auth?client_id=cms-www&response_type=code&scope=openid%20email%20profile&redirect_uri=https%3A//www.ecmwf.int/openid-connect/). Once your user account has been verified you can get your personal access token or *key* by visiting one of the Data Stores user profiles, for example the CDS [user profile](https://cds.climate.copernicus.eu/profile). 
+registering](https://www.ecmwf.int/user/login). Once your user account has been verified you can get your API token (or `key` in `ecmwfr`) by visiting one of the Data Stores user profiles, for example the CDS [user profile](https://cds.climate.copernicus.eu/profile). 
 
 The Personal Access Token is a long string of letters and numbers:
 

--- a/README.md
+++ b/README.md
@@ -102,12 +102,13 @@ to the ECMWF using [the public forum](https://forum.ecmwf.int/t/changes-to-grib-
 Create a ECMWF account by [self
 registering](https://www.ecmwf.int/user/login). Once your user account has been verified you can get your API token (or `key` in `ecmwfr`) by visiting one of the Data Stores user profiles, for example the CDS [user profile](https://cds.climate.copernicus.eu/profile). 
 
-The Personal Access Token is a long string of letters and numbers:
+The API Token is a [UUID](https://fr.wikipedia.org/wiki/Universally_unique_identifier) and should look something like:
 
-``` json
-Personal Access Token: abcd1234-foo-bar-98765431-XXXXXXXXXX
 ```
-This Personal Access Token gives you access to all Data Store services, including the climate atmosphere and emergency management services. This information is required to be able to retrieve data via the `ecmwfr` package. Use the
+API: abcd1234-foo-bar-98765431-XXXXXXXXXX
+```
+
+This API Token gives you access to all Data Store services, including the climate atmosphere and emergency management services. This information is required to be able to retrieve data via the `ecmwfr` package. Use the
 `ecmwfr` [`wf_set_key`](references/wf_set_key.html) function to store
 your login information in the system keyring (see below).
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ This Personal Access Token gives you access to all Data Store services, includin
 `ecmwfr` [`wf_set_key`](references/wf_set_key.html) function to store
 your login information in the system keyring (see below).
 
+In order to download the data, you will also need to accept the licence agreement on the bottom of the [user profile page](https://cds.climate.copernicus.eu/profile).
+
 ### Setup
 
 You have to save your login information before proceeding. The

--- a/vignettes/advanced_vignette.Rmd
+++ b/vignettes/advanced_vignette.Rmd
@@ -30,7 +30,7 @@ This is a brief overview of some of the more advanced options in the `ecmwfr` pa
 
 ## Piped requests
 
-Another hidden feature of `ecmwfr` is the fact that the request is the first argument in the `wf_request()` function. This means that any valid list can be piped into this function (using the %>% or pipe symbol).
+Another hidden feature of `ecmwfr` is the fact that the request is the first argument in the `wf_request()` function. This means that any valid list can be piped into this function (using the magrittr `%>%` or native pipe symbol `|>`).
 
 ```{r eval = FALSE}
 list(
@@ -52,7 +52,7 @@ list(
 
 Once a valid request has been created it can be made into a dynamic function using `achetypes`. Archetype functions are build using a valid `ecmwfr` ECMWF or CDS request and the vector naming the field which are to be set as dynamic.
 
-The `wf_archetype()` function creates a new function with as parameters the dynamic fields previously assigned. The below example show how to use the function to generate the custom `dynamic_request()` function. We then use this new function to alter the `area` and `day` fields and pipe (%>%) into the `wf_request()` function to retrieve the data.
+The `wf_archetype()` function creates a new function with as parameters the dynamic fields previously assigned. The below example show how to use the function to generate the custom `dynamic_request()` function. We then use this new function to alter the `day` and `target` fields and pipe (`|>`) into the `wf_request()` function to retrieve the data.
 
 ```{r eval = FALSE}
 # this is an example of a request
@@ -72,7 +72,8 @@ dynamic_request <- wf_archetype(
   dynamic_fields = c("day", "target"))
 
 # change the day of the month
-dynamic_request(day = "01", target = "new.grib")
+dynamic_request(day = "01", target = "new.grib") |>
+  wf_request()
 ```
 
 ## Batch (parallel) requests
@@ -147,9 +148,9 @@ files <- wf_request_batch(
 For those familiar to ECMWF _mars_ syntax: CDS/ADS does not
 accept `date = "2000-01-01/to/2000-12-31"` specifications at the moment. It is possible to specify one specific date via `date = "2000-01-01"` or multiple days via `date = ["2000-01-01","2000-01-02","2000-10-20"]` or `date = "YYYY-MM-DD/YYYY-MM-DD"` but not via `".../to/..."`.
 
-## Environmental variables
+## Environmental variables for API token
 
-Alternatively, you can set an environmental variable containing your API. 
+Alternatively to using `wf_set_key()`, you can set an environmental variable containing your API. 
 
 ```{r eval=FALSE}
  Sys.setenv(ecmwfr_PAT="abcd1234-foo-bar-98765431-XXXXXXXXXX")

--- a/vignettes/advanced_vignette.Rmd
+++ b/vignettes/advanced_vignette.Rmd
@@ -149,7 +149,7 @@ accept `date = "2000-01-01/to/2000-12-31"` specifications at the moment. It is p
 
 ## Environmental variables
 
-Alternatively, you can set an environmental variable containing your Personal Access Token. 
+Alternatively, you can set an environmental variable containing your API. 
 
 ```{r eval=FALSE}
  Sys.setenv(ecmwfr_PAT="abcd1234-foo-bar-98765431-XXXXXXXXXX")


### PR DESCRIPTION
I noticed that CDS is now calling the "Personal Access token" a "API token". It's been a bit confusing, but probably best stick to their name convension, right?

Here are some minor edits (feel free to reject, not offended). 

Also, in terms of structure, I could see the heading "Use: ECMWF Data Store services" becoming "Setup" including the content for retrieving the token within this section and start a new level 2 section for Data Requests

"File and system based keychains" sounds more like for the advanced_vignette as well as the issue with date which is now present in both. 