### PR TITLE
Patch file format inconsistencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ecmwfr
 Title: Interface to 'ECMWF' and 'CDS' Data Web Services
-Version: 2.0.4
+Version: 2.0.3
 Authors@R: c(person(
                family = "Hufkens",
                given = "Koen",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,8 @@ Imports:
     memoise,
     getPass,
     R6,
-    keyring
+    keyring,
+    tools
 License: AGPL-3
 ByteCompile: true
 RoxygenNote: 7.3.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,7 @@
-# ecmwfr 2.0.4
+# ecmwfr 2.0.3
 
 * fix of Addin conversion issue (edge case)
 * documentation corrections by @Rafnuss
-
-# ecmwfr 2.0.3
-
 * fix of feedback on failed downloads
 
 # ecmwfr 2.0.2

--- a/R/service-ds.R
+++ b/R/service-ds.R
@@ -156,7 +156,7 @@ ds_service <- R6::R6Class("ecmwfr_ds",
       ) {
 
       # Check if download is actually needed
-      if (private$downloaded == TRUE & file.exists(private$file) & !force_redownload) {
+      if (private$downloaded == TRUE & !force_redownload) {
         if (private$verbose) message("File already downloaded")
         return(self)
       }
@@ -191,7 +191,39 @@ ds_service <- R6::R6Class("ecmwfr_ds",
         )
       }
 
+      # flag as downloaded
       private$downloaded <- TRUE
+
+      # no target file provided
+      # use temp file name (assignment
+      # of extension see below)
+      if(length(private$file) ==  0){
+        private$file <- temp_file
+      }
+
+      # check extension
+      if(tools::file_ext(private$file_url) != tools::file_ext(private$file)){
+
+        # list old and new name
+        old_file <- private$file
+        new_file <- paste0(
+          tools::file_path_sans_ext(private$file),".",
+          tools::file_ext(private$file_url)
+        )
+
+        # assign to internal variable
+        private$file <- new_file
+
+        # provide feedback
+        if (private$verbose){
+          message(
+            sprintf(
+              "- renaming output format -> %s to %s",
+              old_file, new_file
+            )
+          )
+        }
+      }
 
       # Copy data from temporary file to final location
       move <- suppressWarnings(file.rename(temp_file, private$file))

--- a/R/wf_request.R
+++ b/R/wf_request.R
@@ -12,7 +12,7 @@
 #' used to retrieve the token set by \code{\link[ecmwfr]{wf_set_key}}
 #' @param path path were to store the downloaded data
 #' @param time_out how long to wait on a download to start (default =
-#' \code{3*3600} seconds).
+#' \code{3600} seconds).
 #' @param retry polling frequency of submitted request for downloading (default =
 #' \code{30} seconds).
 #' @param transfer logical, download data TRUE or FALSE (default = TRUE)

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,14 +1,17 @@
-## New release v2.0.4
+## New release v2.0.3
 
 Dear CRAN team,
 
 This small update fixes an edge case in the RStudio Addin for conversion
 of ECMWF python to R queries. Mention of the keyword `dataset` was filtered
 properly only to select the first instance, not allowing multiple selections
-which as cause for an error. No further changes were made.
+which as cause for an error. In addition, the CDS API now returns zip or 
+netCDF/grib files depending on the requested data. To address this dynamic 
+naming the requested file name is now renamed automatically if not matching the 
+extension on the download url. A small typo in the documentation is also fixed.
 
 Stats on code coverage and test routines remain the same as per previous
-v2.0.3 release.
+v2.0.2 release.
 
 Kind regards,
 Koen Hufkens
@@ -18,7 +21,7 @@ http://cran.r-project.org/web/packages/policies.html
 
 ## test environments, local, CI and r-hub
 
-- local Ubuntu 22.04 install on R 4.4.1
+- local Ubuntu 22.04 install on R 4.4.2
 - Ubuntu 22.04 on github actions (devel / release / macos / windows)
 - codecove.io code coverage at ~70%
 

--- a/man/wf_request.Rd
+++ b/man/wf_request.Rd
@@ -38,7 +38,7 @@ used to retrieve the token set by \code{\link[ecmwfr]{wf_set_key}}}
 \item{path}{path were to store the downloaded data}
 
 \item{time_out}{how long to wait on a download to start (default =
-\code{3*3600} seconds).}
+\code{3600} seconds).}
 
 \item{retry}{polling frequency of submitted request for downloading (default =
 \code{30} seconds).}


### PR DESCRIPTION
Automatically fixes file format inconsistencies upon download. Renames the file based upon the format in the download URL if different from the requested file name.